### PR TITLE
patchram.service: Set baudrate to 3000000.

### DIFF
--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
@@ -5,7 +5,7 @@ Description=Load firmware into bluetooth chip
 Type=simple
 ExecStartPre=/bin/sleep 8
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
-ExecStart=/usr/bin/brcm_patchram_plus --enable_lpm --enable_hci --no2bytes --patchram /vendor/firmware/4343A0.hcd /dev/ttyHS0
+ExecStart=/usr/bin/brcm_patchram_plus --baudrate 3000000 --enable_lpm --enable_hci --no2bytes --patchram /vendor/firmware/4343A0.hcd /dev/ttyHS0
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Fixes immense audio stuttering. I do not know if this impacts battery life. I took this change from hardware/broadcom/libbt/include/vnd_sturgeon.txt.

If you want me to I can create separate PRs for the other platforms. I just don't have the devices to test this for the other platforms ofcourse :)