### PR TITLE
sensorfw: Delay sensorfw service startup.

### DIFF
--- a/recipes-nemomobile/sensorfw/sensorfw/sensorfwd.service
+++ b/recipes-nemomobile/sensorfw/sensorfw/sensorfwd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sensor daemon for sensor framework
+After=dbus.socket
+Requires=dbus.service
+Conflicts=actdead.target
+
+[Service]
+Type=forking
+ExecStartPre=/bin/sleep 4
+ExecStart=/usr/sbin/sensorfwd -c=/etc/sensorfw/primaryuse.conf -d --log-level=warning --no-magnetometer-bg-calibration
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=graphical.target

--- a/recipes-nemomobile/sensorfw/sensorfw_git.bbappend
+++ b/recipes-nemomobile/sensorfw/sensorfw_git.bbappend
@@ -1,1 +1,4 @@
+FILESEXTRAPATHS_prepend_sturgeon := "${THISDIR}/sensorfw:"
+SRC_URI_append_sturgeon = " file://sensorfwd.service"
+
 DEPENDS_append_sturgeon = " libhybris "


### PR DESCRIPTION
Sometimes sensorhd and sensorfwd are started at the same time.
This causes sensorfwd to fail while opening a connection to the sensor daemon.
Delaying sensorfwd startup fixes this issue.