### PR TITLE
sensorfw: Set delay for Hrm and wrist sensor.

### DIFF
--- a/recipes-nemomobile/sensorfw/sensorfw/0001-HybrisWristGestureAdaptor-Set-default-delay.patch
+++ b/recipes-nemomobile/sensorfw/sensorfw/0001-HybrisWristGestureAdaptor-Set-default-delay.patch
@@ -1,0 +1,25 @@
+From 9d2480e5e2fea8e3a4a19d48b5006a87162a6800 Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Sat, 4 Apr 2020 22:42:31 +0200
+Subject: [PATCH 1/2] HybrisWristGestureAdaptor: Set default delay. This fixes
+ a problem where when the wrist gesture sensor wouldn't fire when restarted.
+
+---
+ adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp    | 1 ++
+ 1 file changed, 1 insertions(+)
+
+diff --git a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp
+index b84b818..fec268b 100644
+--- a/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp
++++ b/adaptors/hybriswristgestureadaptor/hybriswristgestureadaptor.cpp
+@@ -45,6 +45,7 @@ HybrisWristGestureAdaptor::HybrisWristGestureAdaptor(const QString& id) :
+     	sensordLogW() << "Path does not exists: " << powerStatePath;
+     	powerStatePath.clear();
+     }
++    setInterval(200, 0);
+ }
+ 
+ HybrisWristGestureAdaptor::~HybrisWristGestureAdaptor()
+-- 
+2.26.0
+

--- a/recipes-nemomobile/sensorfw/sensorfw/0002-HybrisHrmAdaptor-Set-default-delay.patch
+++ b/recipes-nemomobile/sensorfw/sensorfw/0002-HybrisHrmAdaptor-Set-default-delay.patch
@@ -1,0 +1,25 @@
+From 9cc549a0dc2e3a4b47413a9814365fc0fb15f05b Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Sun, 5 Apr 2020 00:03:00 +0200
+Subject: [PATCH 2/2] HybrisHrmAdaptor: Set default delay. This fixes a problem
+ where when the heart rate monitor wouldn't start reading when restarted.
+
+---
+ adaptors/hybrishrmadaptor/hybrishrmadaptor.cpp | 1 ++
+ 1 file changed, 1 insertions(+)
+
+diff --git a/adaptors/hybrishrmadaptor/hybrishrmadaptor.cpp b/adaptors/hybrishrmadaptor/hybrishrmadaptor.cpp
+index a8a9f30..f66f617 100644
+--- a/adaptors/hybrishrmadaptor/hybrishrmadaptor.cpp
++++ b/adaptors/hybrishrmadaptor/hybrishrmadaptor.cpp
+@@ -43,6 +43,7 @@ HybrisHrmAdaptor::HybrisHrmAdaptor(const QString& id) :
+     	sensordLogW() << "Path does not exists: " << powerStatePath;
+     	powerStatePath.clear();
+     }
++    setInterval(200, 0);
+ }
+ 
+ HybrisHrmAdaptor::~HybrisHrmAdaptor()
+-- 
+2.26.0
+

--- a/recipes-nemomobile/sensorfw/sensorfw_git.bbappend
+++ b/recipes-nemomobile/sensorfw/sensorfw_git.bbappend
@@ -1,4 +1,7 @@
 FILESEXTRAPATHS_prepend_sturgeon := "${THISDIR}/sensorfw:"
-SRC_URI_append_sturgeon = " file://sensorfwd.service"
+SRC_URI_append_sturgeon = " file://sensorfwd.service \
+    file://0001-HybrisWristGestureAdaptor-Set-default-delay.patch \
+    file://0002-HybrisHrmAdaptor-Set-default-delay.patch \
+"
 
 DEPENDS_append_sturgeon = " libhybris "


### PR DESCRIPTION
The heart rate sensor only does a one complete reading when no delay is explicitly set.
The wrist gesture sensor will no longer fire when reactivated if no delay is set.

Use the default delay from the Android code to fix these issues.

It took me a long time to come up with the two lines of code that fixes this issue  :laughing: 

This issue closes #6 .
