### PR TITLE
android-init: Allow mdss CX rail to go down to vddmin.

### DIFF
--- a/recipes-android/android-init/android-init/init.rc
+++ b/recipes-android/android-init/android-init/init.rc
@@ -5,6 +5,8 @@ on init
     symlink /dev/fb0 /dev/graphics/fb0
     chown system root /sys/class/timed_output/vibrator/enable
 
+    write /sys/kernel/debug/mdp/allow_cx_vddmin 1
+
     class_start core
 
 service logd /system/bin/logd


### PR DESCRIPTION
During system in idle mode to reduce ambient mode power cost.
Taken from init.sturgeon.rc script.

This should help improve battery life in idle and ambient mode.