### PR TITLE
libhybris: Report support for only OpenGL ES 2.0.

### DIFF
--- a/recipes-core/libhybris/libhybris_git.bbappend
+++ b/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,1 +1,3 @@
+SRC_URI_append_sturgeon = " file://0004-Report-support-for-only-2.0-instead-of-3.0.patch;striplevel=2"
 SRCREV_sturgeon = "8883e9aca7de870a4a93b31e82cfc600c51cef5d"
+


### PR DESCRIPTION
It looks like we experience glitches with OpenGL ES 3.0 (flickering battery icon and clock).

This was observed by dodoradio (on IRC) when using some of the unofficial watchfaces, specifically https://github.com/AsteroidOS/unofficial-watchfaces/blob/15129d7637fb989157ff3fc738b1069781305eab/retro-lcd/usr/share/asteroid-launcher/watchfaces/retro-lcd.qml#L24 was causing the battery icon and clock flickering issue.

This is an alternative solution to patching Qt (Removed since https://github.com/AsteroidOS/meta-asteroid/commit/fc0f44cb74fdc81b7f38e64050e97d8771f9687b)


For reference, this PR solves the following flickering behavior observed in the `retro-lcd` watchface, this watchface uses hardware accelerated rendering.
![output2](https://user-images.githubusercontent.com/7857908/117295826-97bb3580-ae74-11eb-8e3b-7de03dfe0065.gif)

Other relevant PR: https://github.com/AsteroidOS/meta-asteroid/pull/62
